### PR TITLE
Update MOIRE.cpp

### DIFF
--- a/src/MOIRE.cpp
+++ b/src/MOIRE.cpp
@@ -258,6 +258,8 @@ MOIREWidget::MOIREWidget() {
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[0]+21), module, MOIRE::TARGETSCENE_INPUT));
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[7]-6), module, MOIRE::CURRENTSCENE_INPUT));
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+33.9, portY0[7]-6), module, MOIRE::MORPH_INPUT));
+	//with red dot centred on fader above and prt centred on dot
+	//addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+33.6, portY0[7]-6), module, MOIRE::MORPH_INPUT));
 
 	morphButton = createParam<MOIREMorphKnob>(Vec(portX0[0]+27, portY0[3]+15), module, MOIRE::MORPH_PARAM, 0, 10, 0);
 	addParam(morphButton);

--- a/src/MOIRE.cpp
+++ b/src/MOIRE.cpp
@@ -258,7 +258,7 @@ MOIREWidget::MOIREWidget() {
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[0]+21), module, MOIRE::TARGETSCENE_INPUT));
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[7]-6), module, MOIRE::CURRENTSCENE_INPUT));
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+33.9, portY0[7]-6), module, MOIRE::MORPH_INPUT));
-	//with red dot centred on fader above and prt centred on dot
+	//with red dot centred on fader above and port centred on dot
 	//addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+33.6, portY0[7]-6), module, MOIRE::MORPH_INPUT));
 
 	morphButton = createParam<MOIREMorphKnob>(Vec(portX0[0]+27, portY0[3]+15), module, MOIRE::MORPH_PARAM, 0, 10, 0);

--- a/src/MOIRE.cpp
+++ b/src/MOIRE.cpp
@@ -257,7 +257,7 @@ MOIREWidget::MOIREWidget() {
 
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[0]+21), module, MOIRE::TARGETSCENE_INPUT));
 	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+2, portY0[7]-6), module, MOIRE::CURRENTSCENE_INPUT));
-	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+34, portY0[7]-6), module, MOIRE::MORPH_INPUT));
+	addInput(createInput<TinyPJ301MPort>(Vec(portX0[0]+33.9, portY0[7]-6), module, MOIRE::MORPH_INPUT));
 
 	morphButton = createParam<MOIREMorphKnob>(Vec(portX0[0]+27, portY0[3]+15), module, MOIRE::MORPH_PARAM, 0, 10, 0);
 	addParam(morphButton);


### PR DESCRIPTION
Just adjusted the mini port to centre of red dot on the .svg. I had changed the .svg position also so the dot sits centre of the fader above. If you were to change both the x axis and the dot in the .svg the port position would be 33.6

How exactly would you get those positions Iv'e seen them mark differently also in other modules with x and y position relative to the position in inkscape. Just don't get how they should be marked trying to learn.

Here is the .svg with the red dot centred: Port position would be 36.6 when centred on the dot.

[MOIRE.zip](https://github.com/sebastien-bouffier/Bidoo/files/1663716/MOIRE.zip)
