### PR TITLE
Fix build on Windows, VOID is a macro

### DIFF
--- a/src/VOID.cpp
+++ b/src/VOID.cpp
@@ -1,6 +1,9 @@
 #include "plugin.hpp"
 #include "BidooComponents.hpp"
 
+// Windows defines VOID as a macro, which breaks the build...
+#undef VOID
+
 using namespace std;
 
 struct VOID : Module {


### PR DESCRIPTION
This is silly, but real.
I have build issues with your plugins for Windows because `VOID` is defined as a macro in Windows headers, which breaks the build :(

```
In file included from /usr/share/mingw-w64/include/minwindef.h:164,
                 from /usr/share/mingw-w64/include/synchapi.h:10,
                 from ../include/mingw-std-threads/mingw.mutex.h:57,
                 from ../include/mingw-compat/mutex:20,
                 from ../src/Rack/include/audio.hpp:4,
                 from ../src/Rack/include/rack.hpp:31,
                 from Bidoo/src/plugin.hpp:1,
                 from Bidoo/src/VOID.cpp:1:
Bidoo/src/VOID.cpp:6:8: error: expected identifier before 'void'
    6 | struct VOID : Module {
      |        ^~~~
Bidoo/src/VOID.cpp:6:13: error: expected unqualified-id before ':' token
    6 | struct VOID : Module {
      |             ^
```
