### PR TITLE
A few more crash fixes

### DIFF
--- a/src/EDSAROS.cpp
+++ b/src/EDSAROS.cpp
@@ -105,8 +105,8 @@ struct EDSAROS : BidooModule {
 	rspl::MipMapFlt	rev_mip_map;
 	rspl::ResamplerFlt voices[16];
 	rspl::ResamplerFlt rev_voices[16];
-	float *sample;
-	float *rev_sample;
+	float *sample = NULL;
+	float *rev_sample = NULL;
 	bool loading = false;
 	std::mutex mylock;
 	int pos = 0;

--- a/src/LIMONADE.cpp
+++ b/src/LIMONADE.cpp
@@ -527,7 +527,7 @@ struct LIMONADE : BidooModule {
 			else if (morphType==2) {
 				morphSpectrumConstantPhase();
 			}
-			delete(wav);
+			free(wav);
 		}
 		table.calcFFT();
 		dirty = true;


### PR DESCRIPTION
2 more simple fixes here.
- EDSAROS did not have a few vars initialized, so constructing and destructing the module without audio running triggered a crash
- LIMONADE had a mismatch of calloc/delete, we cannot mix those. either we use C++ new and delete, or C-style m/calloc and free
