### PR TITLE
Memory fixes

### DIFF
--- a/src/LIMONADE.cpp
+++ b/src/LIMONADE.cpp
@@ -435,7 +435,7 @@ struct LIMONADE : BidooModule {
 	}
 
   ~LIMONADE() {
-		delete(iRec);
+		free(iRec);
 	}
 
 	void process(const ProcessArgs &args) override;

--- a/src/dep/freeverb/allpass.cpp
+++ b/src/dep/freeverb/allpass.cpp
@@ -8,27 +8,32 @@
 
 allpass::allpass()
 {
-	bufidx = 0;
 	buffer = 0;
+	bufidx = 0;
+	bufsize = 0;
+	allocated = false;
 };
 
 allpass::~allpass()
 {
-	//if (buffer) delete buffer;
+	if (allocated) delete[] buffer;
 };
 
 void allpass::setbuffer(float *buf, int size)
 {
 	buffer = buf;
+	bufidx = 0;
 	bufsize = size;
+	allocated = false;
 }
 
 void allpass::changebuffer(float *buf, int size)
 	{
-		if (buffer) {delete buffer;}
+		if (allocated) {delete[] buffer;}
 		buffer = new float[size];
 		bufsize = size;
 		bufidx = 0;
+		allocated = true;
 }
 
 void allpass::mute()

--- a/src/dep/freeverb/allpass.hpp
+++ b/src/dep/freeverb/allpass.hpp
@@ -21,6 +21,7 @@ struct allpass
 	float	*buffer;
 	int		bufsize;
 	int		bufidx;
+	bool	allocated;
 };
 
 inline float allpass::process(float input)

--- a/src/dep/freeverb/comb.cpp
+++ b/src/dep/freeverb/comb.cpp
@@ -9,36 +9,44 @@
 comb::comb()
 {
 	filterstore = 0;
+	bufsize = 0;
 	bufidx = 0;
 	buffer = 0;
+	allocated = false;
 }
 
 comb::~comb()
 {
 	filterstore = 0;
 	bufidx = 0;
-	//if (buffer) delete buffer;
+	if (allocated) delete[] buffer;
 }
 
 
 void comb::setbuffer(float *buf, int size)
 {
 	buffer = buf;
+	bufidx = 0;
 	bufsize = size;
+	filterstore = 0;
+	allocated = false;
 }
 
 void comb::changebuffer(float *buf, int size)
 	{
-		if (buffer) {delete buffer;}
+		if (allocated) {delete[] buffer;}
 		buffer = new float[size];
 		bufsize = size;
 		bufidx = 0;
+		filterstore = 0;
+		allocated = true;
 }
 
 void comb::mute()
 {
 	for (int i=0; i<bufsize; i++)
 		buffer[i]=0;
+	filterstore = 0;
 }
 
 void comb::setdamp(float val)

--- a/src/dep/freeverb/comb.hpp
+++ b/src/dep/freeverb/comb.hpp
@@ -26,6 +26,7 @@ struct comb
 	float	*buffer;
 	int		bufsize;
 	int		bufidx;
+	bool	allocated;
 };
 
 

--- a/src/dep/freeverb/revmodel.cpp
+++ b/src/dep/freeverb/revmodel.cpp
@@ -44,12 +44,17 @@ revmodel::revmodel()
 	allpassR[2].setfeedback(0.5f);
 	allpassL[3].setfeedback(0.5f);
 	allpassR[3].setfeedback(0.5f);
-	setwet(initialwet);
-	setroomsize(initialroom);
-	setdry(initialdry);
-	setdamp(initialdamp);
-	setwidth(initialwidth);
-	setmode(initialmode);
+
+	// safely initialize all values first
+	wet = initialwet * scalewet;	
+	roomsize = (initialroom * scaleroom) + offsetroom;
+	dry = initialdry * scaledry;
+	damp = initialdamp * scaledamp;
+	width = initialwidth;
+	mode = initialmode;
+
+	// now we can call update after all values are initialized
+	update();
 
 	// Buffer will be full of rubbish - so we MUST mute them
 	mute();

--- a/src/dep/quantizer.hpp
+++ b/src/dep/quantizer.hpp
@@ -98,7 +98,7 @@ namespace quantizer {
 
   struct Quantizer {
 
-    float map[12][numScales][120] = {{{0.0f}}};
+    float map[12][numScales][121] = {{{0.0f}}};
 
     Quantizer();
 


### PR DESCRIPTION
Another set of fixes for issues detected by valgrind.
Logs are:

```
==869036== Invalid write of size 4
==869036==    at 0x10ED11C: quantizer::Quantizer::Quantizer() (quantizer.cpp:14)
==869036==    by 0xFB9C61: DTROY::DTROY() (DTROY.cpp:301)
==869036==    by 0xFC1997: rack::CardinalPluginModel<DTROY, DTROYWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Address 0x1f192680 is 0 bytes after a block of size 266,768 alloc'd
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0xFC198C: rack::CardinalPluginModel<DTROY, DTROYWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==

==869036== Mismatched free() / delete / delete []
==869036==    at 0x6E908AF: operator delete(void*) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1038CA1: LIMONADE::~LIMONADE() (LIMONADE.cpp:438)
==869036==    by 0x1038CF1: LIMONADE::~LIMONADE() (LIMONADE.cpp:439)
==869036==    by 0x253B9BA: rack::app::ModuleWidget::setModule(rack::engine::Module*) (ModuleWidget.cpp:70)
==869036==    by 0x253B88E: rack::app::ModuleWidget::~ModuleWidget() (ModuleWidget.cpp:50)
==869036==    by 0x770B3F: rack::app::CardinalModuleWidget::~CardinalModuleWidget() (rack.hpp:25)
==869036==    by 0xF590D7: BidooWidget::~BidooWidget() (plugin.hpp:81)
==869036==    by 0x1049CE3: LIMONADEWidget::~LIMONADEWidget() (LIMONADE.cpp:1362)
==869036==    by 0x1049D03: LIMONADEWidget::~LIMONADEWidget() (LIMONADE.cpp:1362)
==869036==    by 0x6B3CB2: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:508)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==  Address 0x1f896040 is 0 bytes inside a block of size 8,388,608 alloc'd
==869036==    at 0x6E92A83: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x1038068: LIMONADE::LIMONADE() (LIMONADE.cpp:434)
==869036==    by 0x104A39C: rack::CardinalPluginModel<LIMONADE, LIMONADEWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1106ABF: revmodel::update() (revmodel.cpp:178)
==869036==    by 0x1106D04: revmodel::setwet(float) (revmodel.cpp:234)
==869036==    by 0x1106017: revmodel::revmodel() (revmodel.cpp:47)
==869036==    by 0x10A2A2E: REI::REI() (REI.cpp:56)
==869036==    by 0x10A5529: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x10A551E: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1106ABF: revmodel::update() (revmodel.cpp:178)
==869036==    by 0x1106C34: revmodel::setroomsize(float) (revmodel.cpp:212)
==869036==    by 0x110602D: revmodel::revmodel() (revmodel.cpp:48)
==869036==    by 0x10A2A2E: REI::REI() (REI.cpp:56)
==869036==    by 0x10A5529: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x10A551E: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1106ABF: revmodel::update() (revmodel.cpp:178)
==869036==    by 0x1106CA2: revmodel::setdamp(float) (revmodel.cpp:223)
==869036==    by 0x1106059: revmodel::revmodel() (revmodel.cpp:50)
==869036==    by 0x10A2A2E: REI::REI() (REI.cpp:56)
==869036==    by 0x10A5529: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x10A551E: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==

==869036== Conditional jump or move depends on uninitialised value(s)
==869036==    at 0x1106ABF: revmodel::update() (revmodel.cpp:178)
==869036==    by 0x1106DA4: revmodel::setwidth(float) (revmodel.cpp:255)
==869036==    by 0x110606F: revmodel::revmodel() (revmodel.cpp:51)
==869036==    by 0x10A2A2E: REI::REI() (REI.cpp:56)
==869036==    by 0x10A5529: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==  Uninitialised value was created by a heap allocation
==869036==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==869036==    by 0x10A551E: rack::CardinalPluginModel<REI, REIWidget>::createModule() (helpers.hpp:52)
==869036==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==869036==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==869036==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==869036==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==869036==
```