### PR TITLE
Fix memory leaks

### DIFF
--- a/src/EMILE.cpp
+++ b/src/EMILE.cpp
@@ -102,12 +102,13 @@ struct EMILE : BidooModule {
     fftOut =  (float*)pffft_aligned_malloc(FS*sizeof(float));
 	}
 
-  ~EMILE() {
+  ~EMILE() override {
     pffft_aligned_free(magn);
+    pffft_aligned_free(out);
     pffft_aligned_free(acc);
-    //pffft_destroy_setup(pffftSetup);
     pffft_aligned_free(fftIn);
     pffft_aligned_free(fftOut);
+    pffft_destroy_setup(pffftSetup);
 	}
 
 	void process(const ProcessArgs &args) override;

--- a/src/ZINC.cpp
+++ b/src/ZINC.cpp
@@ -145,6 +145,13 @@ struct ZINC : BidooModule {
 		}
 	}
 
+	~ZINC() override {
+		for (int i = 0; i < BANDS2; i++) {
+			delete iFilter[i];
+			delete cFilter[i];
+		}
+	}
+
 	void process(const ProcessArgs &args) override {
 		float inM = inputs[IN_MOD].getVoltage() / 5.0f;
 		float inC = inputs[IN_CARR].getVoltage() / 5.0f;


### PR DESCRIPTION
As detected by valgrind.
Reported logs:

```
==890428== 16,544 (96 direct, 16,448 indirect) bytes in 1 blocks are definitely lost in loss record 3,593 of 3,615
==890428==    at 0x6E8D899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x24E07FC: pffft_new_setup (pffft.c:1208)
==890428==    by 0xFD742B: EMILE::EMILE() (EMILE.cpp:100)
==890428==    by 0xFD9ED1: rack::CardinalPluginModel<EMILE, EMILEWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 

==890428== 4,160 bytes in 1 blocks are definitely lost in loss record 3,568 of 3,615
==890428==    at 0x6E8D899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x24D36F0: pffft_aligned_malloc (pffft.c:254)
==890428==    by 0xFD73B6: EMILE::EMILE() (EMILE.cpp:96)
==890428==    by 0xFD9ED1: rack::CardinalPluginModel<EMILE, EMILEWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 

==890428== 2,560 bytes in 8 blocks are definitely lost in loss record 3,554 of 3,615
==890428==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x10C21D2: ZINC::ZINC() (ZINC.cpp:143)
==890428==    by 0x10C4EC8: rack::CardinalPluginModel<ZINC, ZINCWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 

==890428== 2,560 bytes in 8 blocks are definitely lost in loss record 3,555 of 3,615
==890428==    at 0x6E8E4C0: operator new(unsigned long, std::align_val_t) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x10C22D7: ZINC::ZINC() (ZINC.cpp:144)
==890428==    by 0x10C4EC8: rack::CardinalPluginModel<ZINC, ZINCWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 
```